### PR TITLE
Fix: Dockerfile COPY instruction in worker-basic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /README.md
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]


### PR DESCRIPTION
### Summary of Fixes
- Corrected the Dockerfile COPY instruction to use 'README.md' instead of 'README'.
- Updated the destination path to '/README.md' for clarity.

### Validation Results
- **Before Fix**: Docker build failed with error: "failed to calculate checksum of ref... '/README': not found"
- **After Fix**: Docker build succeeded without errors.

### Error Reports and Repair Operations
- Original error was due to a missing file 'README' which was incorrectly referenced in the Dockerfile.
- The fix involved changing the COPY instruction to reference the correct file 'README.md'.

### Remaining Issues
- No remaining issues detected after the fix. The repository has been successfully validated.

This pull request addresses the Docker build failure by ensuring the correct file is copied during the build process.