### PR TITLE
fix: correct COPY instruction in Dockerfile to fix build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /README.md
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]


### PR DESCRIPTION
### Motivation

- Fixed the Docker build failure by correcting the COPY instruction in the Dockerfile.
- Changed 'COPY README /' to 'COPY README.md /README.md' to reference the correct filename that exists in the repository.

### Issues closed

- None