### PR TITLE
fix: correct COPY instruction in Dockerfile to use README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /README.md
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]


### PR DESCRIPTION
### Motivation

- Fixed the Docker build failure by correcting the COPY instruction in the Dockerfile.
- The original instruction was trying to copy a non-existent file named 'README', but the actual file is named 'README.md'.

### Issues closed

- No specific issues were closed by this change.