### PR TITLE
fix: update Dockerfile to reference correct README.md filename

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /README.md
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]


### PR DESCRIPTION
### Motivation

- Fixed the Docker build failure by updating the Dockerfile to reference the correct README.md filename.
- The original Dockerfile was trying to copy a file named 'README', but the repository contains 'README.md' instead.

### Issues closed

- None