### PR TITLE
fix: correct COPY instruction in Dockerfile to match actual filename

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]


### PR DESCRIPTION
### Motivation

- Fixed the Dockerfile by changing the COPY instruction from 'COPY README /' to 'COPY README.md /' to match the actual filename in the repository.
- The build was failing because it couldn't find a file named 'README' (without the .md extension).

### Issues closed

- None