### PR TITLE
fix: correct filename in COPY instruction in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]


### PR DESCRIPTION
### Motivation

- Fixed the Docker build failure by correcting the filename in the COPY instruction.
- The Dockerfile was trying to copy a file named 'README', but the actual file in the repository is named 'README.md'.

### Issues closed

- No specific issues were closed by this change.