### PR TITLE
fix: correct COPY instruction in Dockerfile to use README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /README.md
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]


### PR DESCRIPTION
### Motivation

- Fixed the Dockerfile by changing the COPY instruction to use the correct filename README.md instead of README. The build was failing because it couldn't find a file named README, but the repository contains README.md instead.

### Issues closed

- None