### PR TITLE
fix: correct README file reference in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /README.md
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]


### PR DESCRIPTION
### Motivation

- Corrected the Dockerfile to reference the README.md file correctly, ensuring the file is copied with the correct name.
- This change resolves the Docker build failure due to the missing README file.

### Issues closed

- No specific issues were closed, but the Docker build error is resolved.