### PR TITLE
fix: correct Dockerfile to copy README.md with the correct name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /README.md
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]


### PR DESCRIPTION
### Motivation

- Modified the Dockerfile to correctly reference the README.md file instead of README. Changed `COPY README /` to `COPY README.md /README.md` to ensure the file is copied with the correct name.
- This change resolves the Docker build failure due to the missing README file.

### Issues closed

- No specific issues were closed by this change.