### PR TITLE
fix: update Dockerfile to reference correct README file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]


### PR DESCRIPTION
### Motivation

- Modified the Dockerfile to reference the correct README file name (README.md instead of README)
- This change fixes the Docker build error due to the incorrect README file reference.

### Issues closed

- None