### PR TITLE
fix: update Dockerfile to reference README.md in COPY instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]


### PR DESCRIPTION
### Motivation

- Modified the Dockerfile to reference "README.md" instead of "README" in the COPY instruction to fix the Docker build error.

### Issues closed

- None