### PR TITLE
fix: improve Dockerfile with correct README name and pip caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,8 @@ FROM python:3.10-slim
 
 WORKDIR /
 COPY requirements.txt /requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 COPY rp_handler.py /
-
 COPY README.md /
 
 # Start the container


### PR DESCRIPTION
### Motivation

- Fixed the Dockerfile by correcting the COPY instruction for the README file from "README" to "README.md" to match the actual filename in the repository
- Added --no-cache-dir to pip install command for better Docker layer caching and reduced image size
- These changes improve the build reliability and efficiency of the container

### Issues closed

No specific issues were referenced for this fix.