### PR TITLE
fix: correct COPY instruction for README.md in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /README.md
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]


### PR DESCRIPTION
### Motivation

- Fixed the COPY instruction for README.md in Dockerfile to ensure proper file copying during container build
- The fix ensures that the README.md file is correctly copied to the container's root directory

### Issues closed

No specific issues were referenced for this fix.