### PR TITLE
fix: correct README file reference in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]


### PR DESCRIPTION
### Motivation

- Fixed the Dockerfile by correcting the README file reference from "README" to "README.md" to match the actual file in the repository
- This ensures that the Docker build process correctly copies the README file into the container

### Issues closed

No specific issues were referenced for this fix.