### PR TITLE
fix: correct README.md file copy instruction in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /README.md
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]


### PR DESCRIPTION
### Motivation

- Fixed the Dockerfile by correcting the COPY instruction for README file
- Changed `COPY README /` to `COPY README.md /README.md` to match the actual filename in the repository
- This ensures the README file is correctly copied during container build

### Issues closed

No existing issues were referenced for this fix.