### PR TITLE
fix: correct README file reference in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /README.md
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]


### PR DESCRIPTION
### Motivation

- Fixed the Dockerfile by correcting the README file reference from "README" to "README.md"
- Updated the destination path to match the source file name
- Ensures proper file copying during container build

### Issues closed

No specific issues were referenced for this fix.