### PR TITLE
fix: correct README.md file reference in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY rp_handler.py /
 
-COPY README /
+COPY README.md /README.md
 
 # Start the container
 CMD ["python3", "-u", "rp_handler.py"]


### PR DESCRIPTION
### Motivation

- Fixed incorrect README file reference in Dockerfile from "README" to "README.md"
- Updated destination path to match the source file name

### Issues closed

No specific issues were referenced for this fix.