### PR TITLE
fix: ensure test_input.json is included in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /
 COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 COPY handler.py /
-
+COPY test_input.json /
 COPY README.md /
 
 # Start the container


### PR DESCRIPTION
### Motivation

- Fixed Docker container configuration to properly include test_input.json file required by RunPod serverless worker
- Ensures proper testing capabilities in the container environment

### Issues closed

- Fixes issue with missing test_input.json in Docker container